### PR TITLE
explicitly set imagio version and make the corresponding change to th…

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - pandas==1.*
   - albumentations==1.0.*
   - scikit-image
+  - imageio==2.19.3
   - imageio-ffmpeg
   - hyperspy-base
   - bokeh

--- a/rtdefects/io.py
+++ b/rtdefects/io.py
@@ -64,7 +64,7 @@ def encode_as_tiff(data: np.ndarray, compress_level: int = 9) -> bytes:
     # Convert mask to a TIFF-encoded image
     output_img = BytesIO()
     writer = imageio.get_writer(output_img, format='tiff', mode='i')
-    writer.append_data(data, meta={'compress': compress_level})
+    writer.append_data(data, meta={'compression': compress_level})
     return output_img.getvalue()
 
 


### PR DESCRIPTION
…e io API

Intended to fix errors when using `encode_as_tiff` in io.py due to a newer image io version in the user's environment.